### PR TITLE
Fixed NaN bug in Firefox

### DIFF
--- a/flamejam/static/countdown.js
+++ b/flamejam/static/countdown.js
@@ -7,10 +7,6 @@ $.fn.countdown = function() {
 
 };
 
-function isInvalidDate(date) {
-        return isNaN(date.getTime());
-}
-
 
 function leadingZero(num, count) {
     var r = num + '';


### PR DESCRIPTION
le_programmer here. I fixed the NaN bug by changing it using the .split() function in JavaScript and then sending all the values in absolutes. .split() is standardized so it should work fine in other browsers, unlike date formats which are nightmares.
