### PR TITLE
Issue #29: allows clickable repository links.

### DIFF
--- a/flamejam/static/style.css
+++ b/flamejam/static/style.css
@@ -590,12 +590,16 @@ ul.tabs li.default a {
 }
 
 
-span.repo-url {
+a.repo-url {
     background: #CCC;
     padding: 2px 10px;
     font-size: 9pt;
     font-weight: bold;
     color: #555;
+}
+
+a.repo-url:hover {
+	color: #FF4500;
 }
 
 

--- a/flamejam/templates/show_entry.html
+++ b/flamejam/templates/show_entry.html
@@ -62,7 +62,7 @@
                     {% endif %}
 
                     {% if package.type in ["hg", "svn", "git"] %}
-                    <b>{{ package.typeString() }}:</b> <span class="repo-url">{{ package.url }}</span>
+                    <b>{{ package.typeString() }}:</b> <a class="repo-url" href="{{ package.url }}">{{ package.url }}</a>
                     {% else %}
                     <a href="{{ package.url }}">{{ package.typeString() }}</a>
                     {% endif %}


### PR DESCRIPTION
Fixes #29: adds a.repo-url instead of span.repo-url. Allows clickable links.

It was an easy fix. I dislike the hover effect, but kept it because all the other links did it.
