### PR TITLE
#20: UTF allowed in passwords

### DIFF
--- a/flamejam/forms.py
+++ b/flamejam/forms.py
@@ -52,7 +52,7 @@ class LoginValidator(object):
         u = models.Participant.query.filter_by(username = field.data).first()
         if not u:
             raise ValidationError(self.message_username)
-        elif u.password != sha512(form[self.pw_field].data+app.config['SECRET_KEY']).hexdigest():
+        elif u.password != sha512((form[self.pw_field].data+app.config['SECRET_KEY']).encode('utf-8')).hexdigest():
             raise ValidationError(self.message_password)
 
 ############## FORMS ####################

--- a/flamejam/models.py
+++ b/flamejam/models.py
@@ -49,7 +49,7 @@ class Participant(db.Model):
     def __init__(self, username, password, email, is_admin=False,
             is_verified=False, receive_emails = True):
         self.username = username
-        self.password = sha512(password+app.config['SECRET_KEY']).hexdigest()
+        self.password = sha512((password+app.config['SECRET_KEY']).encode('utf-8')).hexdigest()
         self.email = email
         self.is_admin = is_admin
         self.is_verified = is_verified

--- a/flamejam/views.py
+++ b/flamejam/views.py
@@ -39,7 +39,7 @@ def login():
     form = ParticipantLogin()
     if form.validate_on_submit():
         username = form.username.data
-        password = sha512(form.password.data+app.config['SECRET_KEY']).hexdigest()
+        password = sha512((form.password.data+app.config['SECRET_KEY']).encode('utf-8')).hexdigest()
         participant = Participant.query.filter_by(username=username).first()
         if not login_as(participant):
             # not verified


### PR DESCRIPTION
Password was trivial. Should pose no problems with current passwords (utf-8 and ascii are compatible) and also has gone through fuzz testing.

I wanted to do usernames as well but I don't think it's necessary.
