### PR TITLE
Add participants and teams count to current_jam_info api endpoint

### DIFF
--- a/flamejam/views/misc.py
+++ b/flamejam/views/misc.py
@@ -210,7 +210,9 @@ def current_jam_info():
                    announced=str(jam.announced),
                    start_time=str(jam.start_time),
                    duration=jam.duration,
-                   team_limit=jam.team_limit)
+                   team_limit=jam.team_limit,
+                   participants_count=jam.registrations.count(),
+                   teams_count=jam.teams.count())
 
 @app.route('/site_info')
 def site_info():


### PR DESCRIPTION
This exposes some more info about the current jam through the current_jam_info api endpoint.
