### PR TITLE
GamePackage links open in a new tab

### DIFF
--- a/flamejam/models/gamepackage.py
+++ b/flamejam/models/gamepackage.py
@@ -48,7 +48,7 @@ class GamePackage(db.Model):
         self.game = game
 
     def getLink(self):
-        return Markup('<a href="%s">%s</a>' % (self.url, GamePackage.typeString(self.type)))
+        return Markup('<a href="%s" target="_blank">%s</a>' % (self.url, GamePackage.typeString(self.type)))
 
     def getLinkShort(self):
         return Markup('<a href="%s">%s</a>' % (self.url, GamePackage.typeStringShort(self.type)))


### PR DESCRIPTION
After I'm done playing a game, I habitually close the window, expecting to come back to the bgj site. Instead, I end up closing the window which had bgj in its history. This pull request opens game package links in a new tab, so that the expected behavior occurs.

This small patch spares me a lot of trouble if it gets accepted, and I hope it will help others as well - I do not think I am the only one who browses like this.
