### PR TITLE
Fixed bug where screenshots did not show up for games

### DIFF
--- a/flamejam/models/game.py
+++ b/flamejam/models/game.py
@@ -54,7 +54,7 @@ class Game(db.Model):
 
     @property
     def screenshotsOrdered(self):
-        return self.screenshots.order_by(GameScreenshot.index)
+        return sorted(self.screenshots, lambda s1, s2: s1.index - s2.index)
 
     @property
     def score(self):


### PR DESCRIPTION
As some people have noted on IRC, screenshots no longer show up for games. This was probably broken by the database acccessing scheme overhaul, and is fixed in this pull request.
