### PR TITLE
Keep persistent sqlite db when rebuilding container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN apk add --no-cache build-base make python3-dev git libffi-dev postgresql-dev
 	libressl-dev && \
     pip3 install pip -r requirements.txt -r dev-requirements.txt
 
+VOLUME ["/tmp"]
+
 # Clean the repo just in case the repo that built this Docker container wasn't
 # tidy.
 COPY . /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ WORKDIR /app
 COPY requirements.txt dev-requirements.txt /app/
 RUN apk add --no-cache build-base make python3-dev git libffi-dev postgresql-dev linux-headers \
 	libressl-dev && \
-    pip3 install pip -r requirements.txt -r dev-requirements.txt && \
-    apk del build-base linux-headers
+    pip3 install pip -r requirements.txt -r dev-requirements.txt
 
 # Clean the repo just in case the repo that built this Docker container wasn't
 # tidy.

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,12 @@ run: venv
 uwsgi_run: venv
 	venv/bin/uwsgi deploy/uwsgi.ini
 
+.PHONY: setup
+setup: venv
+	python3 -m venv venv
+	venv/bin/flask init-db $(USERNAME) $(PASSWORD) $(EMAIL)
+	venv/bin/flask seed-db
+
 .PHONY: venv
 venv:
 	python3 -m venv venv

--- a/README.md
+++ b/README.md
@@ -33,11 +33,18 @@ not been tested on Windows and it would be quite a wonder indeed if it worked th
 4.  Configure your webserver. If you use Apache with mod\_wsgi, you may use the provided example
     virtualhost `/usr/share/doc/flamejam/apache-vhost.conf`.
 5.  Initialize the database using either test data or an admin account. For this, you can use
-    either of the provided scripts in `/srv/flamejam/scripts/init-db.py` or
-    `/srv/flamejam/scripts/seed-db.py`. If you use `init-db.py` on a production system, call it
-    inside the virtualenv as follows:
+    the provided Makefile option `setup`:
 
-        $ CONFIG_TYPE=production python scripts/init-db.py <username> <password> <email>
+        $ make USERNAME=<username> PASSWORD=<password> EMAIL=<email> setup
+        
+    This will create an initial database setup with an admin user.
+    As an alternative you can also call the commands yourself
+    
+        $ python3 -m venv venv
+        $ venv/bin/flask init-db <username> <password> <email>
+        $ venv/bin/flask seed-db
+        
+    `seed-db` supports an additional command line option `--flood` to setup 1000 dummy users
 
 
 Development

--- a/README.md
+++ b/README.md
@@ -70,3 +70,47 @@ following exceptions:
 These exceptions are subject to their own copyrights and licenses. This project only makes use of them.
 
 For the full license text, please see the included LICENSE file.
+
+
+Run with docker
+---------------
+Flamejam comes with a prepared Dockerfile in order to run it as a container on your system.
+Running flamejam with docker saves you installing all the required dependencies and encapsulates it inside a contained system.
+
+To build the image you need to run as a container you call
+
+    docker build --tag flamejam-image .
+    
+where `flamejam-image` can be freely chosen to name the image. You need to remember it in order to select it for the container.
+Building the container concludes with
+
+    Successfully built 6370906318a8
+    Successfully tagged flamejam-image:latest
+
+By running `docker images` you can see the built image.
+
+    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+    flamejam-image      latest              6370906318a8        24 seconds ago      156MB
+    alpine              3.6                 43773d1dba76        9 months ago        4.03MB
+
+Now you can start the container
+
+    docker run --name flamejam flamejam-image
+    
+and it is up and running. Executing `docker ps` confirms your running container.
+
+    CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS               NAMES
+    16e378d4c10f        flamejam-image      "uwsgi deploy/uwsgi.…"   32 seconds ago      Up 31 seconds       8080/tcp            flamejam
+    
+In order to continue with setting up flamejam you can login to the system by typing
+
+    docker exec -it flamejam sh
+
+Run with docker-compose
+-----------------------
+If you don't like the manual docker running or don't care about configuration options, you can install and use `docker-compose` instead.
+
+    docker-compose up --build
+    
+This uses the provided `docker-compose.yml` configuration. Afterwards you can reach the server in the same way as described above.
+Enter http://localhost:8080 to access the frontpage of the application

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.2'
+services:
+    flamejam:
+      container_name: flamejam
+      build: .
+      ports:
+       - "8080:8080"
+       - "5000:5000"
+      networks:
+        - uwsgi_net
+networks:
+  uwsgi_net:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      - subnet: 192.168.110.0/24

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
        - "5000:5000"
       networks:
         - uwsgi_net
+      volumes:
+        - ./tmp:/tmp
 networks:
   uwsgi_net:
     driver: bridge

--- a/tmp/.gitignore
+++ b/tmp/.gitignore
@@ -1,0 +1,6 @@
+# folder is used from within the docker container
+# - to get outside access to sqlite database
+# - to prevent losing system data when rebuilding the container
+
+*
+!.gitignore


### PR DESCRIPTION
When rebuilding you loose your state from /tmp/flamejam.db thus I extended the docker setup to map /tmp to an outside folder. This way you can decide on your own to have it wiped or keep throughout the restart

This PR is based on my other PR https://github.com/svenstaro/flamejam/pull/132